### PR TITLE
Added ability to delete an expense

### DIFF
--- a/HitApp.Tests/ExpenseControllerTests.cs
+++ b/HitApp.Tests/ExpenseControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using HitApp.Controllers;
 using HitApp.Models;
+using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
@@ -29,6 +30,39 @@ namespace HitApp.Tests
             underTest.Create(expense);
 
             expenseRepo.Received().Create(expense);
+        }
+
+        [Fact]
+        public void Delete_Passes_Correct_Expense_To_View()
+        {
+            var expenseId = 42;
+            var expectedExpense = new Expense();
+
+            expenseRepo.GetById(expenseId).Returns(expectedExpense);
+
+            var result = underTest.Delete(expenseId);
+            var model = ((ViewResult)result).Model;
+
+            Assert.Same(expectedExpense, model);
+        }
+
+        [Fact]
+        public void Delete_Expense_Deletes_The_Expense()
+        {
+            var expenseId = 42;
+            underTest.DeleteExpense(expenseId);
+
+            expenseRepo.Received().Delete(expenseId);
+        }
+
+        [Fact]
+        public void Delete_Redirects_To_Project_Details_After_Delete()
+        {
+            var expenseId = 42;
+            var result = underTest.DeleteExpense(expenseId);
+            var redirectResult = (RedirectToActionResult)result;
+
+            Assert.Same("Details", redirectResult.ActionName);
         }
     }
 }

--- a/HitApp/Controllers/ExpensesController.cs
+++ b/HitApp/Controllers/ExpensesController.cs
@@ -28,5 +28,21 @@ namespace HitApp.Controllers
             ModelState.Clear();
             return View();
         }
+
+        public IActionResult Delete(int id)
+        {
+            var model = expenseRepo.GetById(id);
+            return View(model);
+        }
+
+        [ActionName("Delete")]
+        [HttpPost]
+        public IActionResult DeleteExpense(int id)
+        {
+            expenseRepo.Delete(id);
+            return RedirectToAction("Details", "Projects", new { Id = id});
+            //Dear future us: You will need to pass in project id not expense id to redirect to the right project after delete. Hope you figure it out.//
+            //We're going to need to display it on preoject details page using js. Sincerely, past us.//
+        }
     }
 }

--- a/HitApp/Data/ApplicationDbContext.cs
+++ b/HitApp/Data/ApplicationDbContext.cs
@@ -23,8 +23,10 @@ namespace HitApp.Data
                new Project() { ProjectId = 1, ProjectName = "Bathroom", ProjectStartDate = new DateTime(2017, 9, 19), ProjectEndDate = new DateTime(2018, 1, 18), ProjectContractorInfo = "Jimmy the Tile Guy", ProjectDescription = "Paint and re-tile bathroom walls and floors", ProjectTotalBudget = 10000.00 },
                new Project() { ProjectId = 2, ProjectName = "Kitchen", ProjectStartDate = new DateTime(2017, 10, 11), ProjectEndDate = new DateTime(2018, 1, 18), ProjectContractorInfo = "Jimmy the Tile Guy", ProjectDescription = "Paint and re-tile kitchen walls and floors", ProjectTotalBudget = 12000.00 }
 
-               );
-
+                );
+            modelBuilder.Entity<Expense>().HasData(
+                new Expense() { ExpenseId = 1, ExpenseName = "TestExpense1", ExpenseNotes = "This is a test", ExpenseTotalCost = 420.00}
+                );
             base.OnModelCreating(modelBuilder);
         }
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -36,6 +38,6 @@ namespace HitApp.Data
             base.OnConfiguring(optionsBuilder);
         }
 
-
+    
     }
 }

--- a/HitApp/Data/Migrations/20181126161237_ExpensesDeleteTest.Designer.cs
+++ b/HitApp/Data/Migrations/20181126161237_ExpensesDeleteTest.Designer.cs
@@ -4,14 +4,16 @@ using HitApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace HitApp.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181126161237_ExpensesDeleteTest")]
+    partial class ExpensesDeleteTest
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HitApp/Data/Migrations/20181126161237_ExpensesDeleteTest.cs
+++ b/HitApp/Data/Migrations/20181126161237_ExpensesDeleteTest.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HitApp.Data.Migrations
+{
+    public partial class ExpensesDeleteTest : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Expenses",
+                columns: new[] { "ExpenseId", "ExpenseName", "ExpenseNotes", "ExpenseTotalCost" },
+                values: new object[] { 1, "TestExpense1", "This is a test", 420.0 });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Expenses",
+                keyColumn: "ExpenseId",
+                keyValue: 1);
+        }
+    }
+}

--- a/HitApp/IExpenseRepository.cs
+++ b/HitApp/IExpenseRepository.cs
@@ -9,5 +9,7 @@ namespace HitApp
     public interface IExpenseRepository
     {
         void Create(Expense expense);
+        Expense GetById(int expenseId);
+        void Delete(int expenseId);
     }
 }

--- a/HitApp/Views/Expenses/Delete.cshtml
+++ b/HitApp/Views/Expenses/Delete.cshtml
@@ -1,0 +1,39 @@
+﻿@model HitApp.Models.Expense
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h2>Delete</h2>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>Expense</h4>
+    <hr />
+    <dl class="dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.ExpenseName)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.ExpenseName)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.ExpenseTotalCost)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.ExpenseTotalCost)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.ExpenseNotes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.ExpenseNotes)
+        </dd>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="hidden" asp-for="ExpenseId" />
+        <input type="submit" value="Delete" class="btn btn-default" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+</div>


### PR DESCRIPTION
Maggie and Tim coded the functionality of deleting an expense and redirecting to project details page. However, we need to figure out how to make it redirect to the project that the expense belongs to. As of right now it redirects to whatever project id matches the expense id example: expense id = 1 so it redirects to project of id 1. We will revisit this issue after hooking up the assocoiation between projects and expenses.