### PR TITLE
Add Expense Details to the Project details view

### DIFF
--- a/HitApp/Data/ApplicationDbContext.cs
+++ b/HitApp/Data/ApplicationDbContext.cs
@@ -25,7 +25,7 @@ namespace HitApp.Data
 
                 );
             modelBuilder.Entity<Expense>().HasData(
-                new Expense() { ExpenseId = 1, ExpenseName = "TestExpense1", ExpenseNotes = "This is a test", ExpenseTotalCost = 420.00, ProjectId = 1}
+                new Expense() { ExpenseId = 1, ExpenseName = "TestExpense1", ExpenseNotes = "This is a test", ExpenseCost = 420.00, ProjectId = 1, ProductUrl = "https://www.homedepot.com/p/Warehouse-of-Tiffany-Stella-12-in-Bronze-Accent-Desk-Lamp-with-Red-Dragonfly-Shade-305RBTL/206800480" }
                 );
             base.OnModelCreating(modelBuilder);
         }

--- a/HitApp/Data/Migrations/20181129181720_AddedProductUrlToExpenseModel.Designer.cs
+++ b/HitApp/Data/Migrations/20181129181720_AddedProductUrlToExpenseModel.Designer.cs
@@ -4,14 +4,16 @@ using HitApp.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace HitApp.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181129181720_AddedProductUrlToExpenseModel")]
+    partial class AddedProductUrlToExpenseModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HitApp/Data/Migrations/20181129181720_AddedProductUrlToExpenseModel.cs
+++ b/HitApp/Data/Migrations/20181129181720_AddedProductUrlToExpenseModel.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace HitApp.Data.Migrations
+{
+    public partial class AddedProductUrlToExpenseModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "ExpenseTotalCost",
+                table: "Expenses",
+                newName: "ExpenseCost");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProductUrl",
+                table: "Expenses",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Expenses",
+                keyColumn: "ExpenseId",
+                keyValue: 1,
+                column: "ProductUrl",
+                value: "https://www.homedepot.com/p/Warehouse-of-Tiffany-Stella-12-in-Bronze-Accent-Desk-Lamp-with-Red-Dragonfly-Shade-305RBTL/206800480");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProductUrl",
+                table: "Expenses");
+
+            migrationBuilder.RenameColumn(
+                name: "ExpenseCost",
+                table: "Expenses",
+                newName: "ExpenseTotalCost");
+        }
+    }
+}

--- a/HitApp/Models/Expense.cs
+++ b/HitApp/Models/Expense.cs
@@ -15,9 +15,9 @@ namespace HitApp.Models
         public string ExpenseName { get; set; }
 
         [Required]
-        [Display(Name = "Total Cost")]
+        [Display(Name = "Cost")]
         [DisplayFormat(DataFormatString = "{0:C}", ApplyFormatInEditMode = false)]
-        public double ExpenseTotalCost { get; set; }
+        public double ExpenseCost { get; set; }
 
         [Display(Name = "Date Purchased")]
         [DataType(DataType.Date)]
@@ -31,5 +31,8 @@ namespace HitApp.Models
         [Required]
         [Display(Name = "Project Id")]
         public int ProjectId { get; set; }
+
+        [Display(Name = "Product Link")]
+        public string ProductUrl { get; set; }
     }
 }

--- a/HitApp/Views/Expenses/Create.cshtml
+++ b/HitApp/Views/Expenses/Create.cshtml
@@ -33,6 +33,11 @@
                 <span asp-validation-for="ExpenseDatePurchased" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="ProductUrl" class="control-label"></label>
+                <input asp-for="ProductUrl" class="form-control" />
+                <span asp-validation-for="ProductUrl" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="ExpenseNotes" class="control-label"></label>
                 <input asp-for="ExpenseNotes" class="form-control" />
                 <span asp-validation-for="ExpenseNotes" class="text-danger"></span>

--- a/HitApp/Views/Expenses/Create.cshtml
+++ b/HitApp/Views/Expenses/Create.cshtml
@@ -23,9 +23,9 @@
                 <span asp-validation-for="ExpenseName" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="ExpenseTotalCost" class="control-label"></label>
-                <input asp-for="ExpenseTotalCost" class="form-control" />
-                <span asp-validation-for="ExpenseTotalCost" class="text-danger"></span>
+                <label asp-for="ExpenseCost" class="control-label"></label>
+                <input asp-for="ExpenseCost" class="form-control" />
+                <span asp-validation-for="ExpenseCost" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="ExpenseDatePurchased" class="control-label"></label>

--- a/HitApp/Views/Expenses/Delete.cshtml
+++ b/HitApp/Views/Expenses/Delete.cshtml
@@ -18,10 +18,10 @@
             @Html.DisplayFor(model => model.ExpenseName)
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.ExpenseTotalCost)
+            @Html.DisplayNameFor(model => model.ExpenseCost)
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.ExpenseTotalCost)
+            @Html.DisplayFor(model => model.ExpenseCost)
         </dd>
         <dt>
             @Html.DisplayNameFor(model => model.ExpenseDatePurchased)

--- a/HitApp/Views/Expenses/Delete.cshtml
+++ b/HitApp/Views/Expenses/Delete.cshtml
@@ -30,6 +30,12 @@
             @Html.DisplayFor(model => model.ExpenseDatePurchased)
         </dd>
         <dt>
+            @Html.DisplayNameFor(model => model.ProductUrl)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.ProductUrl)
+        </dd>
+        <dt>
             @Html.DisplayNameFor(model => model.ExpenseNotes)
         </dt>
         <dd>

--- a/HitApp/Views/Expenses/Edit.cshtml
+++ b/HitApp/Views/Expenses/Edit.cshtml
@@ -31,6 +31,11 @@
                 <input asp-for="ExpenseNotes" class="form-control" />
                 <span asp-validation-for="ExpenseNotes" class="text-danger"></span>
             </div>
+            <div class="form-group">
+                <label asp-for="ProductUrl" class="control-label"></label>
+                <input asp-for="ProductUrl" class="form-control" />
+                <span asp-validation-for="ProductUrl" class="text-danger"></span>
+            </div>
             <div class="form-group" id="project-id">
                 <label asp-for="ProjectId" class="control-label"></label>
                 <input asp-for="ProjectId" class="form-control" />

--- a/HitApp/Views/Expenses/Edit.cshtml
+++ b/HitApp/Views/Expenses/Edit.cshtml
@@ -19,9 +19,9 @@
                 <span asp-validation-for="ExpenseName" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="ExpenseTotalCost" class="control-label"></label>
-                <input asp-for="ExpenseTotalCost" class="form-control" />
-                <span asp-validation-for="ExpenseTotalCost" class="text-danger"></span>
+                <label asp-for="ExpenseCost" class="control-label"></label>
+                <input asp-for="ExpenseCost" class="form-control" />
+                <span asp-validation-for="ExpenseCost" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="ExpenseDatePurchased" class="control-label"></label>

--- a/HitApp/Views/Home/Dashboard.cshtml
+++ b/HitApp/Views/Home/Dashboard.cshtml
@@ -25,7 +25,7 @@
             <a href="/projects/details/@project.ProjectId"> See Details</a>
         </div>
         <div class="right-card">
-            <p>Budget: @project.ProjectTotalBudget</p>
+            <p>Budget: $@project.ProjectTotalBudget</p>
             <p>Expenses Go HERE</p>
         </div>
     </div>

--- a/HitApp/Views/Projects/Details.cshtml
+++ b/HitApp/Views/Projects/Details.cshtml
@@ -61,13 +61,13 @@
 <div>
     <h4>Expenses</h4>
 
-    @foreach (var expense in Model.Expenses)
+    @*@foreach (var expense in Model.Expenses)
     {
         <ul>
             <li>Expense Name: @expense.ExpenseName 
                 <ul>
-                    <li>Total Cost: @expense.ExpenseTotalCost</li>
-                    <li>Date Purchased: @expense.ExpenseDatePurchased</li>
+                    <li>Total Cost: $@expense.ExpenseTotalCost</li>
+                    <li>Date Purchased: @expense.ExpenseDatePurchased.ToShortDateString()</li>
                     <li>Notes: @expense.ExpenseNotes</li>
                 </ul> 
             </li>
@@ -76,9 +76,54 @@
                 <a asp-controller="Expenses" asp-action="Delete" asp-route-id="@expense.ExpenseId">Delete</a>
             </li>
         </ul>
-    }
+    }*@
 
-   
+    <table class="table">
+        <thead>
+            <tr>
+                <th>
+                    Name
+                </th>
+                <th>
+                    Total Cost
+                </th>
+                <th>
+                    Date Purchased
+                </th>
+                <th>
+                    Notes
+                </th>
+
+
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Model.Expenses)
+            {
+                <tr>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.ExpenseName)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.ExpenseTotalCost)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.ExpenseDatePurchased)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.ExpenseNotes)
+                    </td>
+
+                    <td>
+
+                        <a asp-controller="Expenses" asp-action="Edit" asp-route-id="@item.ExpenseId">Edit</a>
+                        <a asp-controller="Expenses" asp-action="Delete" asp-route-id="@item.ExpenseId">Delete</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
 
 </div>
  <div>

--- a/HitApp/Views/Projects/Details.cshtml
+++ b/HitApp/Views/Projects/Details.cshtml
@@ -64,9 +64,17 @@
     @foreach (var expense in Model.Expenses)
     {
         <ul>
-            <li>@expense.ExpenseName</li>
-            <a asp-controller="Expenses" asp-action="Edit" asp-route-id="@expense.ExpenseId">Edit</a>
-            <a asp-controller="Expenses" asp-action="Delete" asp-route-id="@expense.ExpenseId">Delete</a>
+            <li>Expense Name: @expense.ExpenseName 
+                <ul>
+                    <li>Total Cost: @expense.ExpenseTotalCost</li>
+                    <li>Date Purchased: @expense.ExpenseDatePurchased</li>
+                    <li>Notes: @expense.ExpenseNotes</li>
+                </ul> 
+            </li>
+            <li id="expense-links">
+                <a asp-controller="Expenses" asp-action="Edit" asp-route-id="@expense.ExpenseId">Edit</a>
+                <a asp-controller="Expenses" asp-action="Delete" asp-route-id="@expense.ExpenseId">Delete</a>
+            </li>
         </ul>
     }
 

--- a/HitApp/Views/Projects/Details.cshtml
+++ b/HitApp/Views/Projects/Details.cshtml
@@ -91,6 +91,9 @@
                     Date Purchased
                 </th>
                 <th>
+                    Product Link
+                </th>
+                <th>
                     Notes
                 </th>
 
@@ -106,12 +109,15 @@
                         @Html.DisplayFor(modelItem => item.ExpenseName)
                     </td>
                     <td>
-                        @Html.DisplayFor(modelItem => item.ExpenseTotalCost)
+                        @Html.DisplayFor(modelItem => item.ExpenseCost)
                     </td>
                     <td>
                         @Html.DisplayFor(modelItem => item.ExpenseDatePurchased)
                     </td>
                     <td>
+                        <a href="@Html.DisplayFor(modelItem => item.ProductUrl)">@Html.DisplayFor(modelItem => item.ExpenseName)</a>
+                    </td>
+                    <td class="truncate">
                         @Html.DisplayFor(modelItem => item.ExpenseNotes)
                     </td>
 

--- a/HitApp/Views/Projects/Details.cshtml
+++ b/HitApp/Views/Projects/Details.cshtml
@@ -117,7 +117,7 @@
                     <td>
                         <a href="@Html.DisplayFor(modelItem => item.ProductUrl)">@Html.DisplayFor(modelItem => item.ExpenseName)</a>
                     </td>
-                    <td class="truncate">
+                    <td title="@Html.DisplayFor(modelItem => item.ExpenseNotes)" class="truncate">
                         @Html.DisplayFor(modelItem => item.ExpenseNotes)
                     </td>
 

--- a/HitApp/wwwroot/css/site.css
+++ b/HitApp/wwwroot/css/site.css
@@ -22,6 +22,16 @@ body {
     list-style: none;
 }
 
+table {
+    white-space: nowrap;
+}
+
+.truncate {
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* Wrapping element */
 /* Set some basic padding to keep content from hitting the edges */
 .body-content {

--- a/HitApp/wwwroot/css/site.css
+++ b/HitApp/wwwroot/css/site.css
@@ -16,7 +16,11 @@ body {
 
 #project-id {
     display: none;
-}    
+} 
+
+#expense-links {
+    list-style: none;
+}
 
 /* Wrapping element */
 /* Set some basic padding to keep content from hitting the edges */


### PR DESCRIPTION
I added a $ to the budget in the dashboard view, added expense details to project details page as a nested ordered list, added ProductUrl to expense model, renamed expense prop ExpenseTotalCost to ExpenseCost, corrected seed data, fixed the view for expense cost, added migration and updated database, updated project details view to include ProductUrl field, truncated notes field in the project details view, added tootip for expenseNotes column of table on project details page, added the Product Link field to the expenses create, edit, and delete views.